### PR TITLE
Add a missing instruction needed to configure trusted CA certificates for GoRouter

### DIFF
--- a/docs-content/index.html.md.erb
+++ b/docs-content/index.html.md.erb
@@ -110,7 +110,7 @@ The following table provides version and version-support information about WSO2 
     </tr>
     <tr>
         <td>Compatible Ops Manager version(s)</td>
-        <td>2.5.x</td>
+        <td>2.5.x, 2.6.x</td>
     </tr>
     <tr>
        <td>BOSH stemcell version</td>

--- a/docs-content/installing.html.md.erb
+++ b/docs-content/installing.html.md.erb
@@ -10,8 +10,8 @@ This topic describes how to install and configure WSO2 API Manager for PCF.
 ##<a id='install'></a> Configure trusted CA certificates for GoRouter
 To configure trusted CA certificates for GoRouter, do the following:
 
-1. In Ops Manager, select the PAS Tile.
-1. Go to the **Network** pane in the **Settings** tab.
+1. In Ops Manager, select the PAS tile.
+1. Go to the **Networking** pane in the **Settings** tab.
 1. Append the following to the **Certificate Authorities Trusted by Router and HAProxy**.
 
     ```
@@ -57,6 +57,9 @@ To configure trusted CA certificates for GoRouter, do the following:
     -----END CERTIFICATE-----
      ```
 1. Click **Save**.
+
+1. Return to the Ops Manager Installation Dashboard and click **Apply changes** to apply the changes
+to the PAS tile.
 
 ##<a id='install'></a> Install and Configure WSO2 API Manager
 


### PR DESCRIPTION
Content of the PR:
1. Add instruction to redeploy the PAS tile after adding the certs.
2. Fix the **networking** pane name.